### PR TITLE
Do not strip single spaces inside elements

### DIFF
--- a/src/utils/strip-whitespace.js
+++ b/src/utils/strip-whitespace.js
@@ -1,28 +1,11 @@
-const cheerio = require('cheerio');
-
-const cleanElementText = ($, $el) => {
-  const contents = $el.contents()[0];
-
-  if (contents && contents.type === 'text') {
-    const { data = '' } = contents;
-    const cleaned = data.replace(/\s\s+/g, ' ').trim();
-    contents.data = cleaned;
-  }
-  if ($el.children().length) {
-    $el.children().each(function () {
-      cleanElementText($, $(this));
-    });
-  }
-};
-
 module.exports = (html) => {
   const str = (html || '')
-    .replace(/[\r\n\f\v\t\b\\]/g, ' ')
+    .replace(/[\r\n\f\v\t\b\\]/g, '  ')
+    .replace(/&nbsp;/g, ' ')
     .trim()
     .replace(/>\s+</g, '><')
     .replace(/\s+%{\[/g, '%{[')
-    .replace(/\]}%\s+/g, ']}%');
-  const $ = cheerio.load(str, { decodeEntities: false });
-  cleanElementText($, $('body'));
-  return $('body').html();
+    .replace(/\]}%\s+/g, ']}%')
+    .replace(/\s\s+/g, ' ');
+  return str;
 };

--- a/test/rules/pennwell/default.spec.js
+++ b/test/rules/pennwell/default.spec.js
@@ -23,7 +23,7 @@ describe('rules/pennwell/default', () => {
       <p>Hello, World</p>\t
     `;
     const result = await rule(body);
-    expect(result.html.cleaned).to.equal('<div><span>Bar</span><span>Foo Bar</span><span>Baz Bar</span></div><p>Hello, World</p>');
+    expect(result.html.cleaned).to.equal('<div><span>Bar </span><span>Foo Bar</span><span>Baz Bar</span></div><p>Hello, World</p>');
   });
   it('should remove <form> elements.', async () => {
     const body = `

--- a/test/utils/strip-whitespace.spec.js
+++ b/test/utils/strip-whitespace.spec.js
@@ -13,7 +13,7 @@ describe('utils/strip-whitespace', () => {
       <p>Hello, World</p>\t
     `;
     const result = stripWhitespace(body);
-    expect(result).to.equal('<div><span>Bar</span><span>Foo<span>Bar Foo</span></span><span>Baz Bar</span></div><p>Hello, World</p>');
+    expect(result).to.equal('<div><span>Bar </span><span>Foo <span> Bar Foo</span></span><span>Baz Bar</span></div><p>Hello, World</p>');
   });
   it('should return an empty string for null values.', async () => {
     expect(stripWhitespace()).to.equal('');


### PR DESCRIPTION
Prevents inline elements from having too much whitespace removed. Prevents issues when spaces surrounding certain elements (`<a>`, `<span>`, `<em>`, `<i>`, `<strong>` etc) were removed, causing the text to "run together" when viewed in browser.

For example:
`<p>Hello <a href="">World</a></p>`  would become  `<p>Hello<a href="">World</a></p>`  which would be rendered as `Hello[link]World[/link]` instead of `Hello [link]World[/link]`